### PR TITLE
Add tests and create `ParentProfileBackend` with business logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,8 +96,7 @@ Once everything is up-and-running via docker-compose you can access
 
 - <http://localhost:9000>
 
-When making changes to the code the servers running in Docker will pick up those changes. Once everything is done re-building you should be able to
-see your changes by refreshing the page.
+When making changes to the code the servers running in Docker will pick up those changes. Once everything is done re-building and tests run successfully, you should be able to see your changes by refreshing the page.
 
 **Making changes to the database**
 

--- a/scala-backend/Dockerfile
+++ b/scala-backend/Dockerfile
@@ -22,5 +22,5 @@ COPY . .
 EXPOSE 9000
 
 # Start sbt with file watching
-CMD ["sbt", "~reStart"]
+CMD ["sbt", "~test;reStart"]
 

--- a/scala-backend/build.sbt
+++ b/scala-backend/build.sbt
@@ -16,7 +16,8 @@ libraryDependencies ++= Seq(
   "com.typesafe.slick" %% "slick" % "3.3.3",
   "com.typesafe.slick" %% "slick-hikaricp" % "3.3.3",
   "mysql" % "mysql-connector-java" % "8.0.26",
-  "ch.megard" %% "akka-http-cors" % "1.1.3"
+  "ch.megard" %% "akka-http-cors" % "1.1.3",
+  "org.scalatest" %% "scalatest" % "3.2.19" % "test"
 )
 
 

--- a/scala-backend/src/main/scala/domain/Models.scala
+++ b/scala-backend/src/main/scala/domain/Models.scala
@@ -4,4 +4,3 @@ case class ParentProfile(id: Long, name: String, child: String)
 case class ChildProfile(id: Long, parentId: Long, name: String)
 case class PaymentMethod(id: Long, parentId: Long, method: String, isActive: Boolean)
 case class Invoice(id: Long, parentId: Long, amount: Double, date: String)
-

--- a/scala-backend/src/main/scala/domain/ParentProfileBackend.scala
+++ b/scala-backend/src/main/scala/domain/ParentProfileBackend.scala
@@ -1,0 +1,25 @@
+package domain
+
+case class ParentProfileBackend(allParentProfiles: Seq[ParentProfile], allInvoices: Seq[Invoice], allPaymentMethods: Seq[PaymentMethod]) {
+
+  def createParentProfile(parent: String, child: String) = this.copy(allParentProfiles = allParentProfiles :+ ParentProfile(allParentProfiles.length + 1, parent, child))
+
+  def parentProfile(id: Long) = allParentProfiles.find(_.id == id)
+
+  def createInvoice(parentId: Int, amount: Double, date: String) = this.copy(allInvoices = allInvoices :+ Invoice(allInvoices.length + 1, parentId, amount, date))
+
+  def invoices(id: Long) = allInvoices.filter(_.parentId == id)
+
+  def createPaymentMethod(parentId: Int, method: String, isActive: Boolean) = this.copy(allPaymentMethods = allPaymentMethods :+ PaymentMethod(allPaymentMethods.length + 1, parentId, method, isActive))
+
+  def deletePaymentMethod(parentId: Long, method: String) =
+    this.copy(allPaymentMethods = allPaymentMethods.filterNot(pm => pm.parentId == parentId && pm.method == method))
+
+  def paymentMethods(parentId: Long) = allPaymentMethods.filter(_.parentId == parentId).toList
+
+  def paymentMethod(id: Long)= allPaymentMethods.find(_.id == id)
+
+  def setActivePaymentMethod(parentId: Long, methodId: Long) =
+    this.copy(allPaymentMethods = allPaymentMethods.map(paymentMethod =>
+      paymentMethod.copy(isActive = paymentMethod.parentId == parentId && paymentMethod.id == methodId)))
+}

--- a/scala-backend/src/test/scala/PaymentMethodsTests.scala
+++ b/scala-backend/src/test/scala/PaymentMethodsTests.scala
@@ -1,0 +1,99 @@
+import domain._
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers._
+
+class PaymentMethodsTests extends AnyFreeSpec with should.Matchers {
+  private val parentProfileBackend =
+    ParentProfileBackend(
+      allParentProfiles = Nil,
+      allInvoices = Nil,
+      allPaymentMethods = Nil)
+
+  "Parent profile" - {
+    "When no parent profile exists yet, there should be none" in {
+      parentProfileBackend.parentProfile(1) shouldBe None
+    }
+
+    "When the first parent is created, it should be there with the id of 1, because the id's are incremented every time a parent is created" in {
+      parentProfileBackend
+        .createParentProfile(parent = "Alice", child = "Bob")
+        .parentProfile(1) shouldBe Some(ParentProfile(id = 1, name = "Alice", child = "Bob"))
+    }
+
+    "When a parent is created, and there is a parent already, the new one should have an id of 2" in {
+      parentProfileBackend
+        .createParentProfile(parent = "Alice", child = "Bob")
+        .createParentProfile(parent = "Charlie", child = "David")
+        .parentProfile(2) shouldBe Some(ParentProfile(id = 2, name = "Charlie", child = "David"))
+    }
+  }
+
+  "Invoices" - {
+    "When no invoices are created yet, there should be none" in {
+      parentProfileBackend
+        .createParentProfile(parent = "Alice", child = "Bob")
+        .invoices(1) shouldBe empty
+    }
+
+    "When the first invoice is created, it should be there with the id of 1, because the id's are incremented every time an invoice is created" in {
+      parentProfileBackend
+        .createParentProfile(parent = "Alice", child = "Bob")
+        .createInvoice(parentId = 1, amount = 100.0, date = "2021-10-01")
+        .invoices(1) should contain(Invoice(id = 1, parentId = 1, amount = 100.0, date = "2021-10-01"))
+    }
+
+    "When an invoices is created, and there is an invoice already, the new one should have an id of 2" in {
+      parentProfileBackend
+        .createParentProfile(parent = "Alice", child = "Bob")
+        .createInvoice(parentId = 1, amount = 100.0, date = "2021-10-01")
+        .createInvoice(parentId = 1, amount = 200.0, date = "2021-11-01")
+        .invoices(1) should contain(Invoice(id = 2, parentId = 1, amount = 200.0, date = "2021-11-01"))
+    }
+  }
+
+  "Payment methods" - {
+    "When no payment methods are created yet, there should be none" in {
+      parentProfileBackend.paymentMethods(1) shouldBe empty
+    }
+
+    "When the first payment method is created, it should be there with the id of 1, because the id's are incremented every time a payment method is created" in {
+      parentProfileBackend
+        .createParentProfile(parent = "Alice", child = "Bob")
+        .createPaymentMethod(parentId = 1, method = "Credit Card", isActive = true)
+        .paymentMethods(1) should contain(PaymentMethod(id = 1, parentId = 1, method = "Credit Card", isActive = true))
+    }
+
+    "When a payment method is created, and there is a payment method already, the new one should have an id of 2" in {
+      parentProfileBackend
+        .createParentProfile(parent = "Alice", child = "Bob")
+        .createPaymentMethod(parentId = 1, method = "Credit Card", isActive = false)
+        .createPaymentMethod(parentId = 1, method = "Debit Card", isActive = true)
+        .paymentMethods(1) should contain(PaymentMethod(id = 2, parentId = 1, method = "Debit Card", isActive = true))
+    }
+
+    "When a payment method is deleted it should go away, because we don't want to keep payment methods around due to privacy concerns" in {
+      parentProfileBackend
+        .createParentProfile(parent = "Alice", child = "Bob")
+        .createPaymentMethod(parentId = 1, method = "Credit Card", isActive = true)
+        .deletePaymentMethod(parentId = 1, method = "Credit Card")
+        .paymentMethods(1) should (not contain(PaymentMethod(id = 1, parentId = 1, method = "Credit Card", isActive = true)))
+    }
+
+    "When setting a payment method active, it should deactivate the current active one and activate the new one, so that we don't have multiple active payment methods" in {
+      parentProfileBackend
+        .createParentProfile(parent = "Alice", child = "Bob")
+        .createPaymentMethod(parentId = 1, method = "Credit Card", isActive = false)
+        .createPaymentMethod(parentId = 1, method = "Debit Card", isActive = true)
+        .setActivePaymentMethod(parentId = 1, methodId = 1)
+        .paymentMethods(1) should contain(PaymentMethod(id = 1, parentId = 1, method = "Credit Card", isActive = true))
+    }
+
+    "When a payment method is added, we should be able to get it by id, so what we can show the newly added payment method" in {
+      parentProfileBackend
+        .createParentProfile(parent = "Alice", child = "Bob")
+        .createParentProfile(parent = "Charlie", child = "David")
+        .createPaymentMethod(parentId = 2, method = "Credit Card", isActive = true)
+        .paymentMethod(1) shouldBe Some(PaymentMethod(id = 1, parentId = 2, method = "Credit Card", isActive = true))
+    }
+  }
+}


### PR DESCRIPTION
Our coding challenge didn't have any tests in it, which I really want it to, so that any potentiel candidates can showcase their testing skills.

I choose Scalatest as the test framework, as this is also what we're using in our codebase.

In order to make the code unit-testable I had to change quite a few things;
	- Create `ParentProfileBackend` to contain the testable business logic
	- Move business logic from `ProfileRepository` to `ParentProfileBackend`
	- Change `GraphQLSchema` to use the pure `ParentProfileBackend` functions sandwiched between the impure `ProfileRepository`

Because `ProfileRepository` no longer contained any business logic, the function names no longer made a lot of sense - the responsibility of `ProfileRepository` is only about persisting changes to the database (CRUD), so I renamed the functions to reflect that; creating, retrieving, updating and deleting. The use-case specific names are now in `ParentProfileBackend`.

There is a gotcha, though. The domain model, in `Models.scala`, is also used as rows in `ProfileRepository`. So they act as both the domain model and the data model. This is not too big of a deal, but it does mean that the domain model has to deal with `id` and know about incrementing it when creating new ones.
A cleaner way would be to separate them, but I want to keep it as simple as possible and it's not really a problem in a coding challenge like this. In real life this wouldn't work for any distributed system as id's would collide all the time - ideally the database should create the id itself, but that means mapping back and forth between the same types in `Models`, which I didn't find ideal.